### PR TITLE
Move Qi tracking into cultivation paths

### DIFF
--- a/Sources/TestMod/TestMod/PathProgress.cs
+++ b/Sources/TestMod/TestMod/PathProgress.cs
@@ -14,12 +14,16 @@ namespace TestMod
         public CultivationPathDef pathDef;
         public int stageIndex;
         public float xp;
+        public float currentQi;
+        public float maxQi;
 
         public void ExposeData()
         {
             Scribe_Defs.Look(ref pathDef, "pathDef");
             Scribe_Values.Look(ref stageIndex, "stageIndex");
             Scribe_Values.Look(ref xp, "xp");
+            Scribe_Values.Look(ref currentQi, "currentQi");
+            Scribe_Values.Look(ref maxQi, "maxQi");
         }
     }
 

--- a/Sources/TestMod/TestMod/Techniques.cs
+++ b/Sources/TestMod/TestMod/Techniques.cs
@@ -45,8 +45,8 @@ namespace TestMod
         public bool CanCast(Pawn pawn, CompCultivator comp)
         {
             if (Find.TickManager.TicksGame < nextUsableTick) return false;
-            if (comp.currentQi < qiCost) return false;
-            if (comp.currentRealm < minRealm) return false;
+            if (!comp.HasQi(qiCost, qiTypeRequirement)) return false;
+            if (comp.CurrentRealm < minRealm) return false;
             if (pathRequirement.HasValue && !comp.paths.Any(p => p.pathDef.pathType == pathRequirement.Value))
                 return false;
             if (qiTypeRequirement.HasValue && !comp.paths.Any(p =>
@@ -67,7 +67,7 @@ namespace TestMod
                 action = () =>
                 {
                     var comp = pawn.TryGetComp<CompCultivator>();
-                    if (comp != null && CanCast(pawn, comp) && comp.ConsumeQi(qiCost))
+                    if (comp != null && CanCast(pawn, comp) && comp.ConsumeQi(qiCost, qiTypeRequirement))
                     {
                         Activate(pawn);
                         nextUsableTick = Find.TickManager.TicksGame + cooldownTicks;


### PR DESCRIPTION
## Summary
- add `currentQi` and `maxQi` to `PathProgress`
- update `CompCultivator` to manage Qi per path and compute `CurrentRealm` dynamically
- adjust techniques to use new Qi API
- update save/load logic

## Testing
- `dotnet build Sources/TestMod/TestMod/TestMod.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687cea8f20d88329b760d548b3ca7797