### PR TITLE
Add breakthrough mechanic on stage advancement

### DIFF
--- a/Sources/TestMod/TestMod/Books.cs
+++ b/Sources/TestMod/TestMod/Books.cs
@@ -46,7 +46,7 @@ namespace TestMod
             var comp = user.TryGetComp<CompCultivator>();
             if (comp != null && Props.pathDef != null && !comp.paths.Any(p => p.pathDef == Props.pathDef))
             {
-                comp.paths.Add(new PathProgress { pathDef = Props.pathDef, stageIndex = 0, xp = 0f });
+                comp.paths.Add(new CultivationPath { pathDef = Props.pathDef, stageIndex = 0, xp = 0f });
                 Messages.Message(user.LabelShort + " изучил путь " + Props.pathDef.label, user, MessageTypeDefOf.PositiveEvent);
             }
         }

--- a/Sources/TestMod/TestMod/CultivationComp.cs
+++ b/Sources/TestMod/TestMod/CultivationComp.cs
@@ -30,7 +30,7 @@ namespace TestMod
         public CompProperties_Cultivator Props => (CompProperties_Cultivator)props;
 
         #region Fields
-        public List<PathProgress> paths = new List<PathProgress>();
+        public List<CultivationPath> paths = new List<CultivationPath>();
         public List<CultivationTechnique> knownTechniques = new List<CultivationTechnique>();
         public int activePathIndex;
         public int CurrentRealm => paths.Any() ? paths.Max(p => p.stageIndex) : 0;
@@ -97,7 +97,7 @@ namespace TestMod
 
         private void HandlePathProgress()
         {
-            List<PathProgress> active = new List<PathProgress>();
+            List<CultivationPath> active = new List<CultivationPath>();
             if (Props.cultivateMultiplePaths)
             {
                 active.AddRange(paths);
@@ -120,13 +120,9 @@ namespace TestMod
                 {
                     p.xp -= stage.needProgressToNextStage;
                     p.stageIndex++;
-                    var nextStage = p.pathDef.stageDefs[p.stageIndex];
-                    if (nextStage.innateTechniques != null)
-                    {
-                        foreach (var tech in nextStage.innateTechniques)
-                            if (!knownTechniques.Contains(tech))
-                                knownTechniques.Add(tech);
-                    }
+                    var nextStageDef = p.pathDef.stageDefs[p.stageIndex];
+                    var stageObj = nextStageDef.CreateStage();
+                    stageObj.Breakthrough(p, this);
                 }
             }
             // Realm is derived dynamically from paths

--- a/Sources/TestMod/TestMod/CultivationPath.cs
+++ b/Sources/TestMod/TestMod/CultivationPath.cs
@@ -24,4 +24,22 @@ namespace TestMod
     }
 
     #endregion
+
+    public class CultivationPath : IExposable
+    {
+        public CultivationPathDef pathDef;
+        public int stageIndex;
+        public float xp;
+        public float currentQi;
+        public float maxQi;
+
+        public void ExposeData()
+        {
+            Scribe_Defs.Look(ref pathDef, "pathDef");
+            Scribe_Values.Look(ref stageIndex, "stageIndex");
+            Scribe_Values.Look(ref xp, "xp");
+            Scribe_Values.Look(ref currentQi, "currentQi");
+            Scribe_Values.Look(ref maxQi, "maxQi");
+        }
+    }
 }

--- a/Sources/TestMod/TestMod/CultivationProgressWindow.cs
+++ b/Sources/TestMod/TestMod/CultivationProgressWindow.cs
@@ -33,7 +33,7 @@ namespace TestMod
             }
         }
 
-        private void DrawPathRow(Rect rect, PathProgress p, CultivationStageDef stage)
+        private void DrawPathRow(Rect rect, CultivationPath p, CultivationStageDef stage)
         {
             Widgets.Label(new Rect(rect.x, rect.y, rect.width, 25f), p.pathDef.label + ": " + stage.label);
             float fillPercent = stage.needProgressToNextStage > 0 ? p.xp / stage.needProgressToNextStage : 1f;

--- a/Sources/TestMod/TestMod/CultivationStage.cs
+++ b/Sources/TestMod/TestMod/CultivationStage.cs
@@ -1,11 +1,7 @@
 using CultivationFramework;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Verse;
-using UnityEngine;
+using RimWorld;
 
 namespace TestMod
 {
@@ -14,11 +10,43 @@ namespace TestMod
         public QiType qiType;
 
         // Multiplier to the base Qi regeneration rate.
-       public float baseRegenMultiplier = 1f;
+        public float baseRegenMultiplier = 1f;
 
         // Techniques unlocked automatically when reached this stage.
-       public List<CultivationTechnique> innateTechniques;
-       public CultivationStageDef currentStage;
-       public float needProgressToNextStage;
+        public List<CultivationTechnique> innateTechniques;
+
+        // XP required to reach the next stage.
+        public float needProgressToNextStage;
+
+        public virtual CultivationStage CreateStage()
+        {
+            return new CultivationStage(this);
+        }
+    }
+
+    public class CultivationStage
+    {
+        public CultivationStageDef def;
+
+        public CultivationStage(CultivationStageDef def)
+        {
+            this.def = def;
+        }
+
+        public virtual void Breakthrough(CultivationPath path, CompCultivator comp)
+        {
+            path.currentQi = 0f;
+            path.maxQi += 10f;
+
+            if (def.innateTechniques != null)
+            {
+                foreach (var tech in def.innateTechniques)
+                    if (!comp.knownTechniques.Contains(tech))
+                        comp.knownTechniques.Add(tech);
+            }
+
+            Messages.Message(comp.parent.LabelShort + " совершил прорыв: " + def.label,
+                comp.parent, MessageTypeDefOf.PositiveEvent);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- introduce `CultivationStage` runtime class with a `Breakthrough` method
- allow `CultivationStageDef` to spawn a `CultivationStage`
- invoke `Breakthrough` when a pawn reaches a new stage

## Testing
- `xbuild Sources/TestMod/TestMod/TestMod.csproj /nologo` *(fails: default MSBuild namespace required)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cf5c73a988329930f7a66aa5a79a8