### PR TITLE
Fix XML errors and add base book def

### DIFF
--- a/Defs/Cultivation/CultivationPathDefs.xml
+++ b/Defs/Cultivation/CultivationPathDefs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
-  <TestMod.CultivationStageDef ParentName=""> <!-- Stage 1 -->
+  <TestMod.CultivationStageDef> <!-- Stage 1 -->
     <defName>CF_Stage_Foundation</defName>
     <label>Foundation</label>
     <qiType>BaseQi</qiType>
@@ -8,7 +8,7 @@
     <needProgressToNextStage>100</needProgressToNextStage>
   </TestMod.CultivationStageDef>
 
-  <TestMod.CultivationStageDef ParentName=""> <!-- Stage 2 -->
+  <TestMod.CultivationStageDef> <!-- Stage 2 -->
     <defName>CF_Stage_Core</defName>
     <label>Core Formation</label>
     <qiType>CoreQi</qiType>

--- a/Defs/ThingDefs/BookBase.xml
+++ b/Defs/ThingDefs/BookBase.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Defs>
+  <ThingDef ParentName="ItemBase" Name="Book" Abstract="True">
+    <thingClass>ThingWithComps</thingClass>
+  </ThingDef>
+</Defs>

--- a/Defs/ThingDefs/PathItems.xml
+++ b/Defs/ThingDefs/PathItems.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
   <ThingDef ParentName="Book" Class="TestMod.PathBookDef">
+    <thingClass>ThingWithComps</thingClass>
     <defName>BookSpiritualPath</defName>
     <label>spiritual path manual</label>
     <description>A book that teaches the Spiritual Path.</description>

--- a/Defs/ThingDefs/QiSource.xml
+++ b/Defs/ThingDefs/QiSource.xml
@@ -4,9 +4,9 @@
     <defName>QiCrystal</defName>
     <label>qi crystal</label>
     <description>A crystal that radiates Qi.</description>
-    <thingClass>ThingWithComps</thingClass>
+    <thingClass>Building</thingClass>
     <graphicData>
-      <texPath>Things/Item/Resource/StoneBlocks/StoneBlocksGranite</texPath>
+      <texPath>Things/Item/Resource/StoneBlocks/BlocksGranite</texPath>
       <graphicClass>Graphic_Single</graphicClass>
     </graphicData>
     <comps>

--- a/Defs/ThingDefs/TechniqueItems.xml
+++ b/Defs/ThingDefs/TechniqueItems.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
   <ThingDef ParentName="Book" Class="TestMod.TechniqueBookDef">
+    <thingClass>ThingWithComps</thingClass>
     <defName>BookGainQi</defName>
     <label>technique manual</label>
     <description>A manual describing how to gather Qi.</description>


### PR DESCRIPTION
## Summary
- add `BookBase.xml` for `Book` parent def
- fix missing thingClass on book items
- correct Qi crystal building definition and texture path
- remove empty `ParentName` from stage defs

## Testing
- `dotnet build Sources/TestMod/TestMod.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687d0f79e1e083298b91f0fa913fc6be