### PR TITLE
Add cultivation inspector tab and spawnable books

### DIFF
--- a/Defs/ThingDefs/BookBase.xml
+++ b/Defs/ThingDefs/BookBase.xml
@@ -2,5 +2,8 @@
 <Defs>
   <ThingDef ParentName="ItemBase" Name="Book" Abstract="True">
     <thingClass>ThingWithComps</thingClass>
+    <thingCategories>
+      <li>Items</li>
+    </thingCategories>
   </ThingDef>
 </Defs>

--- a/Defs/ThingDefs/PathItems.xml
+++ b/Defs/ThingDefs/PathItems.xml
@@ -2,6 +2,9 @@
 <Defs>
   <ThingDef ParentName="Book" Class="TestMod.PathBookDef">
     <thingClass>ThingWithComps</thingClass>
+    <thingCategories>
+      <li>Items</li>
+    </thingCategories>
     <defName>BookSpiritualPath</defName>
     <label>spiritual path manual</label>
     <description>A book that teaches the Spiritual Path.</description>

--- a/Defs/ThingDefs/TechniqueItems.xml
+++ b/Defs/ThingDefs/TechniqueItems.xml
@@ -2,6 +2,9 @@
 <Defs>
   <ThingDef ParentName="Book" Class="TestMod.TechniqueBookDef">
     <thingClass>ThingWithComps</thingClass>
+    <thingCategories>
+      <li>Items</li>
+    </thingCategories>
     <defName>BookGainQi</defName>
     <label>technique manual</label>
     <description>A manual describing how to gather Qi.</description>

--- a/Patches/PatchDefs/AddCultivationTab.xml
+++ b/Patches/PatchDefs/AddCultivationTab.xml
@@ -1,0 +1,8 @@
+<Patch>
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName="Human"]/inspectorTabs</xpath>
+    <value>
+      <li>TestMod.ITab_Cultivation</li>
+    </value>
+  </Operation>
+</Patch>

--- a/Sources/TestMod/TestMod/CultivationComp.cs
+++ b/Sources/TestMod/TestMod/CultivationComp.cs
@@ -187,12 +187,6 @@ namespace TestMod
         #region Gizmos
         public override IEnumerable<Gizmo> CompGetGizmosExtra()
         {
-            yield return new Command_Action
-            {
-                defaultLabel = "Cultivation",
-                defaultDesc = "View cultivation progress",
-                action = () => Find.WindowStack.Add(new Window_CultivationProgress(this))
-            };
             foreach (var tech in knownTechniques)
                 yield return tech.GetGizmo(parent as Pawn);
         }

--- a/Sources/TestMod/TestMod/CultivationTab.cs
+++ b/Sources/TestMod/TestMod/CultivationTab.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using RimWorld;
+using UnityEngine;
+using Verse;
+
+namespace TestMod
+{
+    public class ITab_Cultivation : ITab
+    {
+        public ITab_Cultivation()
+        {
+            size = new Vector2(400f, 300f);
+            labelKey = "Cultivation";
+        }
+
+        private CompCultivator CultivatorComp => SelPawn?.TryGetComp<CompCultivator>();
+
+        protected override void FillTab()
+        {
+            var comp = CultivatorComp;
+            if (comp == null) return;
+            Rect inRect = new Rect(10f, 10f, size.x - 20f, size.y - 20f);
+            float curY = 0f;
+            foreach (var p in comp.paths)
+            {
+                if (p.stageIndex < 0 || p.stageIndex >= p.pathDef.stageDefs.Count) continue;
+                var stage = p.pathDef.stageDefs[p.stageIndex];
+                float rowHeight = 60f;
+                Rect row = new Rect(inRect.x, inRect.y + curY, inRect.width, rowHeight);
+                DrawPathRow(row, p, stage);
+                curY += rowHeight + 10f;
+                if (curY > inRect.height - rowHeight)
+                    break;
+            }
+        }
+
+        private void DrawPathRow(Rect rect, CultivationPath p, CultivationStageDef stage)
+        {
+            Widgets.Label(new Rect(rect.x, rect.y, rect.width, 25f), p.pathDef.label + ": " + stage.label);
+            float fillPercent = stage.needProgressToNextStage > 0 ? p.xp / stage.needProgressToNextStage : 1f;
+            Widgets.FillableBar(new Rect(rect.x, rect.y + 30f, rect.width - 10f, 15f), fillPercent);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow cultivation books to appear in spawn menus by giving them `Items` category
- provide a new `ITab_Cultivation` shown with other pawn tabs
- hook the new tab into pawns via patch
- remove the old gizmo button since the info now lives in the tab

## Testing
- `dotnet build Sources/TestMod/TestMod.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687d157585088329996413a609c0f261